### PR TITLE
Remove sorting on 'dummy' field when no sorting is defined (#issue-64)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,0 @@
-build:
-  environment:
-    php: 7.3

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 
 [![Search Plugin license](https://img.shields.io/github/license/monsieurbiz/SyliusSearchPlugin?public)](https://github.com/monsieurbiz/SyliusSearchPlugin/blob/master/LICENSE.txt)
 [![Build Status](https://img.shields.io/github/workflow/status/monsieurbiz/SyliusSearchPlugin/PHP%20Composer)](https://github.com/monsieurbiz/SyliusSearchPlugin/actions?query=workflow%3A%22PHP+Composer%22)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/monsieurbiz/SyliusSearchPlugin/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/monsieurbiz/SyliusSearchPlugin/?branch=master)
 
 A search plugin for Sylius using [Jane](https://github.com/janephp/janephp) and [Elastically](https://github.com/jolicode/elastically).
 

--- a/src/Fixture/FilterableFixture.php
+++ b/src/Fixture/FilterableFixture.php
@@ -46,7 +46,6 @@ class FilterableFixture extends AbstractResourceFixture implements FilterableFix
      */
     protected function configureResourceNode(ArrayNodeDefinition $resourceNode): void
     {
-        /** @scrutinizer ignore-call */
         $resourceNode
             ->children()
             ->scalarNode('attribute')->end()

--- a/src/Model/Config/GridConfig.php
+++ b/src/Model/Config/GridConfig.php
@@ -120,9 +120,6 @@ class GridConfig
                 // Set sorting
                 $availableSorting = $this->config['sorting']['search'] ?? [];
                 $this->sorting = $this->cleanSorting($request->get('sorting'), $availableSorting);
-                if (!\is_array($this->sorting) || empty($this->sorting)) {
-                    $this->sorting['dummy'] = self::SORT_DESC; // Not existing field to have null in ES so use the score
-                }
 
                 // Set limit
                 $this->limit = max(1, (int) $request->get('limit'));


### PR DESCRIPTION
Hi!
This commit solves the #64 opened by @LucaGallinari. 
As he said in the issue, we don't know why the plugin forces the sort on a "dummy" field when no sort preference has been defined, but removing these lines of code the search works fine.