### PR TITLE
fix(indexation): Default locale if attribute is not translatable

### DIFF
--- a/src/Model/Documentable/DocumentableProductTrait.php
+++ b/src/Model/Documentable/DocumentableProductTrait.php
@@ -172,7 +172,7 @@ trait DocumentableProductTrait
             } else {
                 $attributeValues[] = $attribute->getValue();
             }
-            $document->addAttribute($attribute->getCode(), $attribute->getName(), $attributeValues, $attribute->getLocaleCode(), 1);
+            $document->addAttribute($attribute->getCode(), $attribute->getName(), $attributeValues, $attribute->getLocaleCode() ?? $locale, 1);
         }
 
         return $document;


### PR DESCRIPTION
Fixes https://github.com/monsieurbiz/SyliusSearchPlugin/issues/91