### PR TITLE
Fix retrieving all attributes aggs

### DIFF
--- a/src/Helper/AggregationHelper.php
+++ b/src/Helper/AggregationHelper.php
@@ -39,7 +39,7 @@ class AggregationHelper
             ],
             'aggs' => [
                 'values' => [
-                    'terms' => ['field' => 'attributes.value.keyword'],
+                    'terms' => ['field' => 'attributes.value.keyword', self::MAX_AGGREGATED_ATTRIBUTES_INFO],
                 ],
             ],
         ];


### PR DESCRIPTION
Without this fix `sum_other_doc_count` may be over 0, retrieves just 10 elements.
![изображение](https://user-images.githubusercontent.com/43882627/126594059-7c3bdcec-f7a6-4bfa-bd00-a8e15f0a4a2e.png)