### PR TITLE
Fix DocumentableInterface for use ResultInteface

### DIFF
--- a/src/Model/Documentable/DocumentableInterface.php
+++ b/src/Model/Documentable/DocumentableInterface.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusSearchPlugin\Model\Documentable;
 
-use MonsieurBiz\SyliusSearchPlugin\Model\Document\Result;
+use MonsieurBiz\SyliusSearchPlugin\Model\Document\ResultInterface;
 
 interface DocumentableInterface
 {
     public function getDocumentType(): string;
 
-    public function convertToDocument(string $locale): Result;
+    public function convertToDocument(string $locale): ResultInterface;
 }


### PR DESCRIPTION
Hi ! 

Just noticed since #86, there is an issue cause the DocumentableInterface doesn't use the ResultInterface, whereas the DocumentableProductTrait use it. It cause a compile error: 

![Capture-20210914085648-1567x192](https://user-images.githubusercontent.com/3168281/133210068-74c033b4-5ce5-45c1-8588-482070be5387.png)

This PR should fix that.