### PR TITLE
Add a way to prefix index names with var env

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ monsieur_biz_sylius_search:
             use_main_taxon: true # Use main taxon for the taxon filter, else use the taxons
 ```
 
+If you use the same instance of ElasticSearch for multiples projects, you can avoid collision for index names by setting the `MONSIEURBIZ_SEARCHPLUGIN_ES_PREFIX` environment variable: 
+
+```ini
+# .env.local
+MONSIEURBIZ_SEARCHPLUGIN_ES_PREFIX=my-project
+```
+
 ## Documentable objects
 
 If you want to index an object in the search index, your entity have to implements `MonsieurBiz\SyliusSearchPlugin\Model\Documentable\DocumentableInterface` interface : 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -1,3 +1,6 @@
+parameters:
+  env(MONSIEURBIZ_SEARCHPLUGIN_ES_PREFIX): ''
+
 services:
 
   _defaults:
@@ -37,6 +40,7 @@ services:
           documents-en: \MonsieurBiz\SyliusSearchPlugin\Model\Document\Result
           documents-en_us: \MonsieurBiz\SyliusSearchPlugin\Model\Document\Result
         elastically_bulk_size: 100
+        elastically_index_prefix: '%env(MONSIEURBIZ_SEARCHPLUGIN_ES_PREFIX)%'
 
   # Add JS for plugin
   monsieurbiz_sylius_search.block_event_listener.layout.javascripts:


### PR DESCRIPTION
Hi ! 

I wanted to add a prefix because I use the same instance of elasticSearch for multiples projects. 

I followed [this](https://github.com/monsieurbiz/SyliusSearchPlugin/pull/50#issuecomment-709886492) but I think it should be better to having this directly configurable in the plugin. 

With this PR, any user can add `MONSIEURBIZ_SEARCHPLUGIN_ES_PREFIX` in their `.env.local`. 

WDYT ?