### PR TITLE
Migrate index instead of creating a new one if it exists

### DIFF
--- a/src/Model/Document/Index/Indexer.php
+++ b/src/Model/Document/Index/Indexer.php
@@ -102,10 +102,6 @@ class Indexer extends AbstractIndex
     {
         $indexName = $this->getIndexName($locale);
         $newIndex = $this->getIndexBuilder()->createIndex($indexName);
-        $this->getIndexBuilder()->markAsLive(
-            $newIndex,
-            $indexName
-        );
 
         $repositories = $this->documentRepositoryProvider->getRepositories();
         foreach ($repositories as $repository) {
@@ -113,9 +109,15 @@ class Indexer extends AbstractIndex
             /** @var DocumentableInterface $document */
             foreach ($documents as $document) {
                 Assert::isInstanceOf($document, DocumentableInterface::class);
-                $this->indexOneByLocale($document->convertToDocument($locale), $locale);
+                $convertToDocument = $document->convertToDocument($locale);
+                $this->getIndexer()->scheduleIndex($newIndex, new Document($convertToDocument->getUniqId(), $convertToDocument));
             }
         }
+
+        $this->getIndexBuilder()->markAsLive(
+            $newIndex,
+            $indexName
+        );
 
         $this->getIndexer()->flush();
 


### PR DESCRIPTION
While the populate command is running, you won't get any results for any queries made to ElasticSearch (taxon, search and instant). This is probably due to the fact the the new empty Index that is created is, somehow, immediatly seen as the "active" index, even if the command is still populating it.
I found out [this issue on Elastically](https://github.com/jolicode/elastically/issues/52) where they say this:

> As far as I understand, when I need to update my index while keeping the old data available, I need to call **migrate**, markAsLive and purgeOldIndices

