### PR TITLE
Add fallback in date format

### DIFF
--- a/src/Resources/config/elasticsearch/monsieurbiz_product_mapping.yaml
+++ b/src/Resources/config/elasticsearch/monsieurbiz_product_mapping.yaml
@@ -23,7 +23,7 @@ mappings:
           search_analyzer: standard
     created_at:
       type: date
-      format: yyyy-MM-dd HH:mm:ss
+      format: yyyy-MM-dd HH:mm:ss||strict_date_optional_time||epoch_second
     description:
       type: text
     images:


### PR DESCRIPTION
To avoid error while population in Sylius < 1.11 : 

```
  Error in one or more bulk request actions:

  index: /monsieurbiz_product_fr_2022-04-13-143025/_doc/1 caused failed to parse field [created_at] of type [date] in document with id '1'. Preview of field's value: '2022-04-08T20:12:09+00:00'
  index: /monsieurbiz_product_fr_2022-04-13-143025/_doc/2 caused failed to parse field [created_at] of type [date] in document with id '2'. Preview of field's value: '2022-04-09T18:54:25+00:00'
  index: /monsieurbiz_product_fr_2022-04-13-143025/_doc/3 caused failed to parse field [created_at] of type [date] in document with id '3'. Preview of field's value: '2022-04-11T23:06:07+00:00'
  index: /monsieurbiz_product_fr_2022-04-13-143025/_doc/4 caused failed to parse field [created_at] of type [date] in document with id '4'. Preview of field's value: '2022-04-07T04:10:27+00:00'
  index: /monsieurbiz_product_fr_2022-04-13-143025/_doc/5 caused failed to parse field [created_at] of type [date] in document with id '5'. Preview of field's value: '2022-04-08T08:18:50+00:00'
```