### PR TITLE
Fix pagination pb when page_size different than 10

### DIFF
--- a/src/Search/Response.php
+++ b/src/Search/Response.php
@@ -69,8 +69,8 @@ class Response implements ResponseInterface
     {
         if (null === $this->paginator) {
             $this->paginator = new Pagerfanta($this->adapter);
-            $this->paginator->setCurrentPage($this->requestConfiguration->getPage());
             $this->paginator->setMaxPerPage($this->requestConfiguration->getLimit());
+            $this->paginator->setCurrentPage($this->requestConfiguration->getPage());
         }
 
         return $this->paginator;


### PR DESCRIPTION
Cf. issue #124 
When page size lower than 10, click on latest page produces a 404