### PR TITLE
Correct `index: /<INDEX_NAME>/_doc/<ID> caused failed to parse` errors

### DIFF
--- a/src/Index/Indexer.php
+++ b/src/Index/Indexer.php
@@ -171,11 +171,13 @@ final class Indexer
     }
 
     /**
-     * Convert proxies classes to the entity one
-     * 
+     * Convert proxies classes to the entity one.
+     *
      * This avoid to retrieve the incorrect Mapper and have errors like :
      * `index: /<INDEX_NAME>/_doc/<ID> caused failed to parse`
-     * 
+     *
+     * @param mixed $entity
+     *
      * @return mixed
      */
     private function getRealEntity($entity)
@@ -185,9 +187,9 @@ final class Indexer
         }
 
         // Clear the entity manager to detach the proxy object
-        $this->entityManager->clear(get_class($entity));
+        $this->entityManager->clear(\get_class($entity));
         // Retrieve the original class name
-        $entityClassName = $this->entityManager->getClassMetadata(get_class($entity))->rootEntityName;
+        $entityClassName = $this->entityManager->getClassMetadata(\get_class($entity))->rootEntityName;
         // Find the object in repository from the ID
         return $this->entityManager->find($entityClassName, $entity->getId());
     }


### PR DESCRIPTION
When a related product is loaded in another one, when we have to reindex this product, a Proxy class is loaded and the reindex causes : 

```
  [Elastica\Exception\Bulk\ResponseException]
  Error in one or more bulk request actions:
  index: /monsieurbiz_product_fr_2022-06-02-171613/_doc/495 caused failed to parse
```

I dig a lot and the when it's OK the class is a Product : 
![image](https://user-images.githubusercontent.com/11380627/171697877-397ddc29-2788-4776-97b5-da8ba8fe2c54.png)

And when it's not, I have a proxy class : 
![image](https://user-images.githubusercontent.com/11380627/171697900-91eb765e-b89e-4801-8530-8711c50e938e.png)

With a proxy, the Automapper does not map the product and the DTO is an empty array.
This empty array generate the error.

So I created a method to be sure we have the correct entity, and not a proxy while reindexing.