### PR TITLE
call getPrice only if channelPrice is not null

### DIFF
--- a/src/Model/Documentable/DocumentableProductTrait.php
+++ b/src/Model/Documentable/DocumentableProductTrait.php
@@ -231,8 +231,8 @@ trait DocumentableProductTrait
         foreach ($variants as $variant) {
             $channelPrice = $variant->getChannelPricingForChannel($channel);
             if (null !== $channelPrice && (null === $cheapestPrice || $channelPrice->getPrice() < $cheapestPrice)) {
-                    $cheapestPrice = $channelPrice->getPrice();
-                    $cheapestVariant = $variant;
+                $cheapestPrice = $channelPrice->getPrice();
+                $cheapestVariant = $variant;
             }
         }
 

--- a/src/Model/Documentable/DocumentableProductTrait.php
+++ b/src/Model/Documentable/DocumentableProductTrait.php
@@ -230,9 +230,9 @@ trait DocumentableProductTrait
         $variants = $this->getEnabledVariants();
         foreach ($variants as $variant) {
             $channelPrice = $variant->getChannelPricingForChannel($channel);
-            if (null === $cheapestPrice || $channelPrice->getPrice() < $cheapestPrice) {
-                $cheapestPrice = $channelPrice->getPrice();
-                $cheapestVariant = $variant;
+            if (null !== $channelPrice && (null === $cheapestPrice || $channelPrice->getPrice() < $cheapestPrice)) {
+                    $cheapestPrice = $channelPrice->getPrice();
+                    $cheapestVariant = $variant;
             }
         }
 


### PR DESCRIPTION
Method `$channelPrice = $variant->getChannelPricingForChannel($channel);` return a channelPricingInterface or null. Then we must check the value of `$channelPricing` before calling the method `$channelPricing->getPrice()`