### PR TITLE
Add hash to output javascript filename

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ Encore
 
     // organise files
     .configureFilenames({
-        js: 'js/[name].js'
+        js: 'js/[name].[hash:8].js'
     })
 ;
 


### PR DESCRIPTION
In order to cache assets files, we need a unique output file by adding the hash of the javascript file to the output filename.
