### PR TITLE
Became compatible with channel based index name

### DIFF
--- a/src/EventSubscriber/AppendProductAttributeMappingSubscriber.php
+++ b/src/EventSubscriber/AppendProductAttributeMappingSubscriber.php
@@ -46,7 +46,7 @@ class AppendProductAttributeMappingSubscriber implements EventSubscriberInterfac
 
     public function onMappingProvider(MappingProviderEvent $event): void
     {
-        if ('monsieurbiz_product' !== $event->getIndexCode()) {
+        if (false === (bool) preg_match('/monsieurbiz_product$/', $event->getIndexCode())) {
             return;
         }
         $mapping = $event->getMapping();

--- a/src/Search/Response/FilterBuilders/Product/AttributeFilterBuilder.php
+++ b/src/Search/Response/FilterBuilders/Product/AttributeFilterBuilder.php
@@ -26,7 +26,7 @@ class AttributeFilterBuilder implements FilterBuilderInterface
         string $aggregationCode,
         array $aggregationData
     ): ?array {
-        if ('monsieurbiz_product' !== $documentable->getIndexCode() || 'attributes' !== $aggregationCode) {
+        if (false === (bool) preg_match('/monsieurbiz_product$/', $documentable->getIndexCode()) || 'attributes' !== $aggregationCode) {
             return null;
         }
 

--- a/src/Search/Response/FilterBuilders/Product/MainTaxonFilterBuilder.php
+++ b/src/Search/Response/FilterBuilders/Product/MainTaxonFilterBuilder.php
@@ -26,7 +26,7 @@ class MainTaxonFilterBuilder implements FilterBuilderInterface
         string $aggregationCode,
         array $aggregationData
     ): ?array {
-        if ('monsieurbiz_product' !== $documentable->getIndexCode() || 'main_taxon' !== $aggregationCode) {
+        if (false === (bool) preg_match('/monsieurbiz_product$/', $documentable->getIndexCode()) || 'main_taxon' !== $aggregationCode) {
             return null;
         }
 

--- a/src/Search/Response/FilterBuilders/Product/OptionFilterBuilder.php
+++ b/src/Search/Response/FilterBuilders/Product/OptionFilterBuilder.php
@@ -26,7 +26,7 @@ class OptionFilterBuilder implements FilterBuilderInterface
         string $aggregationCode,
         array $aggregationData
     ): ?array {
-        if ('monsieurbiz_product' !== $documentable->getIndexCode() || 'options' !== $aggregationCode) {
+        if (false === (bool) preg_match('/monsieurbiz_product$/', $documentable->getIndexCode()) || 'options' !== $aggregationCode) {
             return null;
         }
 

--- a/src/Search/Response/FilterBuilders/Product/PriceFilterBuilder.php
+++ b/src/Search/Response/FilterBuilders/Product/PriceFilterBuilder.php
@@ -26,7 +26,7 @@ class PriceFilterBuilder implements FilterBuilderInterface
         string $aggregationCode,
         array $aggregationData
     ): ?array {
-        if ('monsieurbiz_product' !== $documentable->getIndexCode() || 'prices' !== $aggregationCode) {
+        if (false === (bool) preg_match('/monsieurbiz_product$/', $documentable->getIndexCode()) || 'prices' !== $aggregationCode) {
             return null;
         }
 

--- a/src/Search/Response/FilterBuilders/Product/TaxonsFilterBuilder.php
+++ b/src/Search/Response/FilterBuilders/Product/TaxonsFilterBuilder.php
@@ -25,7 +25,7 @@ class TaxonsFilterBuilder
         string $aggregationCode,
         array $aggregationData
     ): ?array {
-        if ('monsieurbiz_product' !== $documentable->getIndexCode() || 'taxons' !== $aggregationCode) {
+        if (false === (bool) preg_match('/monsieurbiz_product$/', $documentable->getIndexCode()) || 'taxons' !== $aggregationCode) {
             return null;
         }
 


### PR DESCRIPTION
In some case you have to override native plugin behaviour to named your index using channel name. Eg: `mychannel__monsieurbiz_product` instead of `monsieurbiz_product`.   
To be compatible with that change, we control the last part of the index name instead of a total equality.
