### PR TITLE
Add an automatic reindex manager to enable or disable event

### DIFF
--- a/src/EventSubscriber/ReindexProductEventSubscriber.php
+++ b/src/EventSubscriber/ReindexProductEventSubscriber.php
@@ -63,6 +63,7 @@ class ReindexProductEventSubscriber implements EventSubscriberInterface, LoggerA
         return [
             Events::onFlush => 'onFlush',
             Events::postFlush => 'postFlush',
+            Events::onClear => 'onClear',
         ];
     }
 
@@ -82,7 +83,7 @@ class ReindexProductEventSubscriber implements EventSubscriberInterface, LoggerA
         if (!$this->automaticProductReindexManager->shouldBeAutomaticallyReindex()) {
             return;
         }
-        
+
         $unitOfWork = $args->getEntityManager()->getUnitOfWork();
         $this->manageUnitOfWork($unitOfWork);
 
@@ -100,6 +101,11 @@ class ReindexProductEventSubscriber implements EventSubscriberInterface, LoggerA
             $this->dispatched = true; // Needed to set before dispatch to avoid infinite calls by message flush containing product
             $this->messageBus->dispatch($productReindexFromIdsMessage);
         }
+    }
+
+    public function onClear(): void
+    {
+        $this->dispatched = false;
     }
 
     private function onFlushEntities(array $entities, string $type = 'insertionsOrUpdate'): void

--- a/src/Manager/AutomaticProductReindexManager.php
+++ b/src/Manager/AutomaticProductReindexManager.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Search plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSearchPlugin\Manager;
+
+class AutomaticProductReindexManager implements AutomaticReindexManagerInterface
+{
+    private bool $shouldAutomaticallyReindex = true;
+
+    public function shouldAutomaticallyReindex(bool $shouldAutomaticallyReindex): void
+    {
+        $this->shouldAutomaticallyReindex = $shouldAutomaticallyReindex;
+    }
+
+    public function shouldBeAutomaticallyReindex(): bool
+    {
+        return $this->shouldAutomaticallyReindex;
+    }
+}

--- a/src/Manager/AutomaticReindexManagerInterface
+++ b/src/Manager/AutomaticReindexManagerInterface
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Search plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSearchPlugin\Manager;
+
+interface AutomaticReindexManagerInterface
+{
+    public function shouldAutomaticallyReindex(bool $shouldAutomaticallyReindex): void;
+
+    public function shouldBeAutomaticallyReindex(): bool;
+}


### PR DESCRIPTION
- feat: add an automatic reindex manager to enable or disable event
- fix: reset the dispatch flag in the event subscribe on clear event

For example, when we have an import product service and have multiple flush, we want to send a reindex message at the end manually. Now, is it possible:

```php
...
// Disable the automatic product search reindex
$this->automaticProductReindexManager->shouldAutomaticallyReindex(false);

...
// Dispatch a message to reindex my current product
$productReindexFromIdsMessage = new ProductReindexFromIds();
$productReindexFromIdsMessage->addProductId($product->getId());
$this->messageBus->dispatch($productReindexFromIdsMessage);

// Re-enable the automatic product search reindex
$this->automaticProductReindexManager->shouldAutomaticallyReindex(true);
```