### PR TITLE
Refactoring of the RepositoryDatasource class and add a datasource for the products

### DIFF
--- a/src/Model/Datasource/DatasourceInterface.php
+++ b/src/Model/Datasource/DatasourceInterface.php
@@ -15,5 +15,7 @@ namespace MonsieurBiz\SyliusSearchPlugin\Model\Datasource;
 
 interface DatasourceInterface
 {
+    public const DEFAULT_MAX_PER_PAGE = 100;
+
     public function getItems(string $sourceClass): iterable;
 }

--- a/src/Model/Datasource/ProductDatasource.php
+++ b/src/Model/Datasource/ProductDatasource.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Search plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSearchPlugin\Model\Datasource;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
+use Pagerfanta\Pagerfanta;
+use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Webmozart\Assert\Assert;
+
+class ProductDatasource implements DatasourceInterface
+{
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function getItems(string $sourceClass): iterable
+    {
+        $repository = $this->entityManager->getRepository($sourceClass);
+        /** @var ProductRepositoryInterface $repository */
+        Assert::isInstanceOf($repository, ProductRepositoryInterface::class);
+
+        $queryBuilder = $repository->createQueryBuilder('o')
+            ->andWhere('o.channels IS NOT EMPTY')
+            ->andWhere('o.enabled = :enabled')
+            ->setParameter('enabled', true)
+        ;
+
+        $paginator = new Pagerfanta(new QueryAdapter($queryBuilder, false, false));
+        $paginator->setMaxPerPage(self::DEFAULT_MAX_PER_PAGE);
+        $page = 1;
+        do {
+            $paginator->setCurrentPage($page);
+
+            foreach ($paginator->getIterator() as $item) {
+                yield $item;
+            }
+            $page = $paginator->hasNextPage() ? $paginator->getNextPage() : 1;
+        } while ($paginator->hasNextPage());
+
+        return null;
+    }
+}

--- a/src/Resources/config/monsieurbiz_search.yaml
+++ b/src/Resources/config/monsieurbiz_search.yaml
@@ -14,7 +14,7 @@ monsieurbiz_sylius_search:
         item: '@MonsieurBizSyliusSearchPlugin/Search/product/_box.html.twig'
         instant: '@MonsieurBizSyliusSearchPlugin/Instant/Product/_box.html.twig'
       #mapping_provider: '...' # by default monsieurbiz.search.mapper_provider
-      #dataprovider: '...' # by default MonsieurBiz\SyliusSearchPlugin\Model\Datasource\RepositoryDatasource
+      datasource: 'MonsieurBiz\SyliusSearchPlugin\Model\Datasource\ProductDatasource' # by default MonsieurBiz\SyliusSearchPlugin\Model\Datasource\RepositoryDatasource
   automapper_classes:
     sources:
       product: '%sylius.model.product.class%'


### PR DESCRIPTION
**Summary**

The new product data source only returns activated products that have a channel to index them in ES.

And I refactored the RepositoryDatasource, it always works with a pagnitor. I increase the batch size, by default is 10.

**Example**

Example, my product with id 10, doesn't have channels:
<img width="1384" alt="image" src="https://user-images.githubusercontent.com/465524/197288027-bc805f51-c4eb-4531-b97f-d86787f00dde.png">

but it is indexed in ES:
<img width="1702" alt="image" src="https://user-images.githubusercontent.com/465524/197288093-caf35b11-1088-40e8-bd21-4fd8a91aa73e.png">

<img width="232" alt="image" src="https://user-images.githubusercontent.com/465524/197288112-28ec2ced-0e1a-49cc-ba7f-49d895f2a308.png">

With the new datasource, the product is not indexing:
<img width="1706" alt="image" src="https://user-images.githubusercontent.com/465524/197288264-b58fc2b0-44b0-4170-84f7-7fbaeb372528.png">
 