### PR TITLE
Add emulate channel context to be able to index in prod 

### DIFF
--- a/src/Context/ChannelSimulationContext.php
+++ b/src/Context/ChannelSimulationContext.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Search plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSearchPlugin\Context;
+
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+use Sylius\Component\Channel\Model\ChannelInterface;
+
+final class ChannelSimulationContext implements ChannelContextInterface
+{
+    private ?ChannelInterface $channel = null;
+
+    public function getChannel(): ChannelInterface
+    {
+        if (null === $this->channel) {
+            throw new ChannelNotFoundException();
+        }
+
+        return $this->channel;
+    }
+
+    public function setChannel(?ChannelInterface $channel): void
+    {
+        $this->channel = $channel;
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -207,3 +207,8 @@ services:
         product_attribute: '@MonsieurBiz\SyliusSearchPlugin\Search\Response\FilterBuilders\Product\AttributeFilterBuilder',
         product_option: '@MonsieurBiz\SyliusSearchPlugin\Search\Response\FilterBuilders\Product\OptionFilterBuilder'
       }
+
+  # Context
+  MonsieurBiz\SyliusSearchPlugin\Context\ChannelSimulationContext:
+    tags:
+      - { name: sylius.context.channel, priority: 128 }


### PR DESCRIPTION
In prod env (`APP_ENV=prod`), with several channels, it was not possible to run the document indexing command:

<img width="830" alt="image" src="https://user-images.githubusercontent.com/465524/197292376-a46e6e7a-54d8-4404-a5cf-136bbf633233.png">

Because the FakeChannelContext is available only in dev env. So I create a new emulate channel context, and:
<img width="497" alt="image" src="https://user-images.githubusercontent.com/465524/197292555-d2f00cf8-fc51-48c8-aae8-ce8c787f4820.png">
