### PR TITLE
Corrects an error when the same locale is used by multiple channels

### DIFF
--- a/src/Index/Indexer.php
+++ b/src/Index/Indexer.php
@@ -130,7 +130,7 @@ final class Indexer implements IndexerInterface
                     $channel->getLocales()->map(function (LocaleInterface $locale): string { return $locale->getCode() ?? ''; })->toArray()
                 );
             }
-            $this->locales = array_filter($this->locales);
+            $this->locales = array_unique(array_filter($this->locales));
         }
 
         return $this->locales;


### PR DESCRIPTION
With 2 channels that use the same locale (e.g. FR), you may get an error `Index "monsieurbiz_product_fr_2022-12-19-064120" is already created, something is wrong.`