### PR TITLE
Add prefix option for names of indexes and aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,9 @@ server.stop: ## Stop the local webserver
 es.reindex: ## Reindex elasticsearch
 	${CONSOLE} monsieurbiz:search:populate
 
+consume.reindex: ## Consume reindex messages during 10min
+	${CONSOLE} messenger:consume async_search --time-limit=600 -vv
+
 doctrine.diff: ## Doctrine diff
 	${CONSOLE} doctrine:migration:diff
 

--- a/dist/config/packages/monsieurbiz_sylius_search_plugin.yaml
+++ b/dist/config/packages/monsieurbiz_sylius_search_plugin.yaml
@@ -1,2 +1,7 @@
 imports:
   - { resource: "@MonsieurBizSyliusSearchPlugin/Resources/config/config.yaml" }
+
+monsieurbiz_sylius_search:
+  documents:
+    monsieurbiz_product:
+      prefix: 'myprefix' # define a custom index prefix

--- a/doc/Tips.md
+++ b/doc/Tips.md
@@ -1,0 +1,17 @@
+# Tips
+
+## Add prefix for index names and aliases
+
+In the `config/packages/monsieurbiz_sylius_search_plugin.yaml` file, add the `prefix` node for documents that need a prefix in the names of indexes and aliases.
+
+Example, for the products index:
+
+```diff
+imports:
+  - { resource: "@MonsieurBizSyliusSearchPlugin/Resources/config/config.yaml" }
+
++monsieurbiz_sylius_search:
++  documents:
++    monsieurbiz_product:
++     prefix: 'myproject' # define a custom index prefix
+```

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue([])
                     ->arrayPrototype()
                         ->children()
+                            ->scalarNode('prefix')->defaultValue(null)->end()
                             ->scalarNode('document_class')->defaultValue(Documentable::class)->end()
                             ->scalarNode('instant_search_enabled')->defaultValue(false)->end()
                             ->scalarNode('source')->isRequired()->cannotBeEmpty()->end()

--- a/src/Index/Indexer.php
+++ b/src/Index/Indexer.php
@@ -80,14 +80,14 @@ final class Indexer implements IndexerInterface
 
             return;
         }
-        $indexName = $this->getIndexName($documentable, $locale);
+        $index = $this->clientFactory->getIndex($documentable, $locale);
         foreach ($documents as $document) {
             if (null !== $locale && $document instanceof TranslatableInterface) {
                 $document->setCurrentLocale($locale);
             }
             $dto = $this->autoMapper->map($document, $documentable->getTargetClass());
             // @phpstan-ignore-next-line
-            $indexer->scheduleIndex($indexName, new Document((string) $document->getId(), $dto));
+            $indexer->scheduleIndex($index, new Document((string) $document->getId(), $dto));
         }
     }
 
@@ -107,12 +107,12 @@ final class Indexer implements IndexerInterface
             return;
         }
 
-        $indexName = $this->getIndexName($documentable, $locale);
+        $index = $this->clientFactory->getIndex($documentable, $locale);
         foreach ($documents as $document) {
             if (null !== $locale && $document instanceof TranslatableInterface) {
                 $document->setCurrentLocale($locale);
             }
-            $indexer->scheduleDelete($indexName, (string) $document->getId());
+            $indexer->scheduleDelete($index, (string) $document->getId());
         }
     }
 
@@ -167,11 +167,6 @@ final class Indexer implements IndexerInterface
         $indexBuilder->markAsLive($newIndex, $indexName);
         $indexBuilder->speedUpRefresh($newIndex);
         $indexBuilder->purgeOldIndices($indexName);
-    }
-
-    private function getIndexName(DocumentableInterface $documentable, ?string $locale = null): string
-    {
-        return $documentable->getIndexCode() . strtolower(null !== $locale ? '_' . $locale : '');
     }
 
     /**

--- a/src/Model/Documentable/Documentable.php
+++ b/src/Model/Documentable/Documentable.php
@@ -15,7 +15,7 @@ namespace MonsieurBiz\SyliusSearchPlugin\Model\Documentable;
 
 use Sylius\Component\Resource\Model\TranslatableInterface;
 
-class Documentable implements DocumentableInterface
+class Documentable implements PrefixedDocumentableInterface
 {
     use DocumentableDatasourceTrait;
 
@@ -33,6 +33,8 @@ class Documentable implements DocumentableInterface
     private array $templates;
 
     private array $limits;
+
+    private ?string $prefix = null;
 
     public function __construct(
         string $indexCode,
@@ -82,5 +84,15 @@ class Documentable implements DocumentableInterface
         }
 
         return $this->limits[$queryType] ?? [];
+    }
+
+    public function getPrefix(): string
+    {
+        return $this->prefix ?? '';
+    }
+
+    public function setPrefix(string $prefix): void
+    {
+        $this->prefix = $prefix;
     }
 }

--- a/src/Model/Documentable/PrefixedDocumentableInterface.php
+++ b/src/Model/Documentable/PrefixedDocumentableInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Search plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusSearchPlugin\Model\Documentable;
+
+interface PrefixedDocumentableInterface extends DocumentableInterface
+{
+    public function getPrefix(): string;
+
+    public function setPrefix(string $prefix): void;
+}

--- a/src/Resources/config/monsieurbiz_search.yaml
+++ b/src/Resources/config/monsieurbiz_search.yaml
@@ -1,6 +1,7 @@
 monsieurbiz_sylius_search:
   documents:
     monsieurbiz_product:
+      #prefix: '…' # define a custom index prefix on index names and aliases
       #document_class: '…' # by default MonsieurBiz\SyliusSearchPlugin\Model\Documentable\Documentable
       instant_search_enabled: true # by default false
       limits:


### PR DESCRIPTION
Close #153 

Now, is it possible to define a `prefix` in the `config/packages/monsieurbiz_sylius_search_plugin.yaml` file. Example for product:

```diff
imports:
  - { resource: "@MonsieurBizSyliusSearchPlugin/Resources/config/config.yaml" }

+monsieurbiz_sylius_search:
+  documents:
+    monsieurbiz_product:
+     prefix: 'myproject' # define a custom index prefix
```

And the names of indexes and aliases are prefixed by the value:
![image](https://user-images.githubusercontent.com/465524/208948742-e08638ef-5eb9-4f4d-aef8-add8d5125a5c.png)
