### PR TITLE
Correct default settings valus when many documentable entities

### DIFF
--- a/src/DependencyInjection/DocumentableRegistryPass.php
+++ b/src/DependencyInjection/DocumentableRegistryPass.php
@@ -65,10 +65,8 @@ class DocumentableRegistryPass implements CompilerPassInterface
             $registry->addMethodCall('register', [$documentableServiceId, new Reference($documentableServiceId)]);
 
             // Add the default settings value of documentable
-            $searchSettings['monsieurbiz.search']['default_values'] = [
-                'instant_search_enabled__' . $indexCode => $documentableConfiguration['instant_search_enabled'],
-                'limits__' . $indexCode => $documentableConfiguration['limits'],
-            ];
+            $searchSettings['monsieurbiz.search']['default_values']['instant_search_enabled__' . $indexCode] = $documentableConfiguration['instant_search_enabled'];
+            $searchSettings['monsieurbiz.search']['default_values']['limits__' . $indexCode] = $documentableConfiguration['limits'];
         }
 
         $container->setParameter('monsieurbiz.settings.config.plugins', $searchSettings);


### PR DESCRIPTION
Else only the last loop values will be saved.
By default it works because we only have one documentable