### PR TITLE
Allows babdev/pagerfanta-bundle version 3 for the latest minor Sylius 1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "~7.4|~8.0",
-        "babdev/pagerfanta-bundle": "^2.5",
+        "babdev/pagerfanta-bundle": "^2.5 || ^3.0",
         "jacquesbh/eater": "^2.0",
         "jane-php/automapper-bundle": "^7.1",
         "jolicode/elastically": "^1.4.0",


### PR DESCRIPTION
The commit [3ee618](https://github.com/Sylius/Sylius/commit/3ee618ceafd32fbb8a56287509dcc3b445831f69) on Sylius allows `babdev/pagerfanta-bundle` in version 3 since version 1.11.12

See the [report of failed job](https://github.com/monsieurbiz/SyliusSearchPlugin/actions/runs/5357947629/jobs/9719542205?pr=158):

![image](https://github.com/monsieurbiz/SyliusSearchPlugin/assets/465524/7888aa50-b729-4a04-b963-cec45dec7165)
