### PR TITLE
Use DTO ID to be able to have custom IDs

### DIFF
--- a/src/Index/Indexer.php
+++ b/src/Index/Indexer.php
@@ -94,7 +94,7 @@ final class Indexer implements IndexerInterface
             }
             $dto = $this->autoMapper->map($document, $documentable->getTargetClass());
             // @phpstan-ignore-next-line
-            $indexer->scheduleIndex($index, new Document((string) $document->getId(), $dto));
+            $indexer->scheduleIndex($index, new Document((string) $dto->getId(), $dto));
         }
     }
 
@@ -184,7 +184,7 @@ final class Indexer implements IndexerInterface
             }
             $dto = $this->autoMapper->map($item, $documentable->getTargetClass());
             // @phpstan-ignore-next-line
-            $indexer->scheduleIndex($newIndex, new Document((string) $item->getId(), $dto));
+            $indexer->scheduleIndex($newIndex, new Document((string) $dto->getId(), $dto));
         }
         $indexer->flush();
 


### PR DESCRIPTION
Be able to use custom method in DTO like : 

```php
    public function getId(): string
    {
        return sprintf('%s_%s', $this->getType(), $this->getObjectId());
    }
```

We not break the default behaviour : 

![image](https://github.com/monsieurbiz/SyliusSearchPlugin/assets/11380627/34daa94f-2699-4605-858e-0e565598750c)

And user be able to customize their DTO IDs