### PR TITLE
Append default analyzer if no locale

### DIFF
--- a/src/Mapping/YamlWithLocaleProvider.php
+++ b/src/Mapping/YamlWithLocaleProvider.php
@@ -91,11 +91,11 @@ class YamlWithLocaleProvider implements MappingProviderInterface
 
     private function appendLocaleAnalyzers(string $configurationDirectory, array $mapping, ?string $locale): array
     {
+        $mapping = $this->appendAnalyzers($configurationDirectory . \DIRECTORY_SEPARATOR . 'analyzers.yaml', $mapping);
+
         if (null === $locale) {
             return $mapping;
         }
-
-        $mapping = $this->appendAnalyzers($configurationDirectory . \DIRECTORY_SEPARATOR . 'analyzers.yaml', $mapping);
 
         foreach ($this->getLocaleCode($locale) as $localeCode) {
             $mapping = $this->appendAnalyzers($configurationDirectory . \DIRECTORY_SEPARATOR . 'analyzers_' . $localeCode . '.yaml', $mapping);


### PR DESCRIPTION
Avoid : 

```
In Http.php line 178:

  Failed to parse mapping [_doc]: analyzer [search_autocomplete] has not been configured in mappings
```