### PR TITLE
Add config with url in checker to avoid error couldn’t resolve host 

### DIFF
--- a/src/Checker/ElasticsearchChecker.php
+++ b/src/Checker/ElasticsearchChecker.php
@@ -19,10 +19,17 @@ class ElasticsearchChecker implements ElasticsearchCheckerInterface
 {
     private ?bool $isAvailable = null;
 
+    private array $config;
+
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
+
     public function check(): bool
     {
         if (null === $this->isAvailable) {
-            $client = (new Factory())->buildClient();
+            $client = (new Factory($this->config))->buildClient();
 
             // Check client response
             try {

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -255,6 +255,9 @@ services:
 
   monsieurbiz.search.checker.elasticsearch_checker:
     class: MonsieurBiz\SyliusSearchPlugin\Checker\ElasticsearchChecker
+    arguments:
+      $config:
+        url: '%monsieurbiz_search_elasticsearch_url%'
 
   MonsieurBiz\SyliusSearchPlugin\Twig\Extension\RenderSearchForm:
     arguments:


### PR DESCRIPTION
If we use a host other than localhost, there's an error in the checker. 

We have the "Couldn't resolve host" exception, so the checker always returns false.