### PR TITLE
Argument unpacking to avoid error when call decorated function with multiple arguments

### DIFF
--- a/src/Routing/RequestContext.php
+++ b/src/Routing/RequestContext.php
@@ -55,7 +55,7 @@ class RequestContext extends BaseRequestContext
     {
         $callback = [$this->decorated, $name];
         if (\is_callable($callback)) {
-            return \call_user_func($callback, $arguments);
+            return \call_user_func($callback, ...$arguments);
         }
 
         throw new Exception(sprintf('Method %s not found for class "%s"', $name, \get_class($this->decorated)));


### PR DESCRIPTION
Avoid error like this : 

```
MonsieurBiz\SyliusCmsPagePlugin\Routing\RequestContext::checkPageSlug(): Argument #1 ($request) must be of type Symfony\Component\HttpFoundation\Request, array given, called in /apps/sylius/vendor/monsieurbiz/sylius-no-commerce-plugin/src/Routing/NoCommerceRequestContext.php on line 60
```