### PR TITLE
Flush index in all cases

### DIFF
--- a/src/Index/Indexer.php
+++ b/src/Index/Indexer.php
@@ -86,8 +86,6 @@ final class Indexer implements IndexerInterface
                 $this->indexByDocuments($documentable, $documents, $localeCode, $indexer);
             }
 
-            $indexer->flush();
-
             return;
         }
         $index = $this->clientFactory->getIndex($documentable, $locale);
@@ -99,6 +97,8 @@ final class Indexer implements IndexerInterface
             // @phpstan-ignore-next-line
             $indexer->scheduleIndex($index, new Document((string) $dto->getId(), $dto));
         }
+
+        $indexer->flush();
     }
 
     public function deleteByDocuments(DocumentableInterface $documentable, array $documents, ?string $locale = null, ?ElasticallyIndexer $indexer = null): void


### PR DESCRIPTION
Currently in the indexer, `indexByDocuments` flushes only when the document is translatable.

With this fix, it flushes in all cases. The only drawback being it now flushes for each locale when it's translatable and no locale was provided which is IMHO acceptable.

Happy to discuss about this !

PS: thanks for the plugin 