### PR TITLE
Force paypal version to avoid error with 1.6 version

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -19,6 +19,10 @@ jobs:
       matrix:
         php: ['7.4' ,'8.0', '8.1']
         sylius: ["~1.9.0", "~1.10.0", "~1.11.0", "~1.12.0"]
+        include:
+          - php: '8.1'
+            sylius: '~1.12.0'
+            sylius_paypal: '~1.5.0'
         exclude:
           - php: 8.1
             sylius: "~1.9.0"
@@ -75,6 +79,14 @@ jobs:
         working-directory: ./sylius
         run: |
             composer require --no-install --no-scripts --no-progress sylius/sylius="${{ matrix.sylius }}"
+
+        # Fix Paypal 1.5 on Sylius 1.12 and PHP 8.1
+      - name: Make sure to install the required version of Sylius Paypal Plugin
+        if: ${{ matrix.sylius_paypal }}
+        working-directory: ./sylius
+        run: |
+            composer require --no-install --no-scripts --no-progress sylius/paypal-plugin="${{ matrix.sylius_paypal }}" # @see https://github.com/Sylius/PayPalPlugin/issues/295
+
 
       - name: Setup some requirements
         working-directory: ./sylius

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ setup_application:
 ${APP_DIR}/docker-compose.yaml:
 	rm -f ${APP_DIR}/docker-compose.yml
 	rm -f ${APP_DIR}/docker-compose.yaml
+	rm -f ${APP_DIR}/compose.yml
+	rm -f ${APP_DIR}/compose.override.dist.yml
 	ln -s ../../docker-compose.yaml.dist ${APP_DIR}/docker-compose.yaml
 .PHONY: ${APP_DIR}/docker-compose.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 SHELL=/bin/bash
 APP_DIR=tests/Application
 SYLIUS_VERSION=1.12.0
+SYLIUS_PAYPAL_VERSION=1.5.0
 SYMFONY=cd ${APP_DIR} && symfony
 COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console
@@ -68,6 +69,7 @@ setup_application:
 	(cd ${APP_DIR} && ${COMPOSER} config minimum-stability dev)
 	(cd ${APP_DIR} && ${COMPOSER} config --no-plugins allow-plugins true)
 	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress sylius/sylius="~${SYLIUS_VERSION}") # Make sure to install the required version of sylius because the sylius-standard has a soft constraint
+	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress sylius/paypal-plugin="~${SYLIUS_PAYPAL_VERSION}") # @see https://github.com/Sylius/PayPalPlugin/issues/295
 	@if [ ${SYLIUS_VERSION} == '1.11.0' ]; then\
 		(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress php-http/message-factory)\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SYMFONY=cd ${APP_DIR} && symfony
 COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console
 export COMPOSE_PROJECT_NAME=search
+export USER_UID=$(shell id -u)
 PLUGIN_NAME=sylius-${COMPOSE_PROJECT_NAME}-plugin
 COMPOSE=docker-compose
 YARN=yarn

--- a/dist/docker-compose.override.yaml
+++ b/dist/docker-compose.override.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
     elasticsearch:
         build:

--- a/dist/docker-compose.override.yaml
+++ b/dist/docker-compose.override.yaml
@@ -21,27 +21,5 @@ services:
             - "9200:9200"
             - "9300:9300"
 
-    cerebro:
-        image: lmenezes/cerebro
-        ports:
-            - "9000:9000"
-        links:
-            - elasticsearch
-
-    kibana:
-        image: kibana:7.4.0
-        ports:
-            - "5601:5601"
-        environment:
-            - "SERVER_NAME=localhost"
-            - "ELASTICSEARCH_HOSTS=http://elasticsearch:9200"
-            - "XPACK_GRAPH_ENABLED=false"
-            - "XPACK_ML_ENABLED=false"
-            - "XPACK_REPORTING_ENABLED=false"
-            - "XPACK_SECURITY_ENABLED=false"
-            - "XPACK_WATCHER_ENABLED=false"
-        links:
-            - elasticsearch
-
 volumes:
     esdata: {}

--- a/docker-compose.yaml.dist
+++ b/docker-compose.yaml.dist
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
     database:
         image: mysql:8.0

--- a/src/Index/Indexer.php
+++ b/src/Index/Indexer.php
@@ -221,7 +221,7 @@ final class Indexer implements IndexerInterface
         }
 
         // Clear the entity manager to detach the proxy object
-        $this->entityManager->clear(\get_class($entity));
+        $this->entityManager->clear(\get_class($entity)); /** @phpstan-ignore-line */
         // Retrieve the original class name
         $entityClassName = $this->entityManager->getClassMetadata(\get_class($entity))->rootEntityName;
         // Find the object in repository from the ID


### PR DESCRIPTION
- Fix PaypalPlugin version to avoid error with Sylius 1.12 and PHP 8.1
- Docker fixes
  - Remove cerebro container in docker-compose to avoid issue with mac 
  - Remove docker files from sylius standard to keep only ours
  - Add USER_ID env var to avoid warning
- fix a phpstan error in Indexer class