### PR TITLE
fix: index translations correctly for taxons and attribute value

### DIFF
--- a/src/AutoMapper/ProductAttributeValueReader/SelectReader.php
+++ b/src/AutoMapper/ProductAttributeValueReader/SelectReader.php
@@ -35,6 +35,10 @@ class SelectReader implements ReaderInterface
         }
 
         $currentLocale = $productAttribute->getLocaleCode();
+        $attribute = $productAttribute->getAttribute();
+        if (null !== $attribute->getTranslation()->getLocale()) {
+            $currentLocale = $attribute->getTranslation()->getLocale();
+        }
         $choices = $productAttribute->getAttribute()->getConfiguration()['choices'] ?? [];
         $productAttributeValue = $productAttribute->getValue();
         if (!is_iterable($productAttributeValue)) {


### PR DESCRIPTION
Without this patch, data indexed in ES is in the default locale.

In Sylius, we have a `postLoad` on entities to add the current locale on the translation entity. But in CLI, it uses the default locale ('%locale%'):

```php
        $fallbackLocale = $this->translationLocaleProvider->getDefaultLocaleCode();
        $translatableEntity->setFallbackLocale($fallbackLocale);

        if ($this->commandBasedChecker !== null && $this->commandBasedChecker->isExecutedFromCLI()) {
            $translatableEntity->setCurrentLocale($fallbackLocale);

            return;
        }
```

We should see if we can't add a similar behavior to the plugin to simplify the code.