### PR TITLE
feat: added taxon to LimitsSearchType

### DIFF
--- a/src/Form/Type/Settings/LimitsSearchType.php
+++ b/src/Form/Type/Settings/LimitsSearchType.php
@@ -49,6 +49,17 @@ class LimitsSearchType extends AbstractType
                 'allow_delete' => true,
             ]
         );
+        $builder->add(
+            'taxon',
+            CollectionType::class,
+            [
+                'entry_type' => IntegerType::class,
+                'label' => 'monsieurbiz_searchplugin.admin.setting_form.limit_taxon_' . $documentable->getIndexCode(),
+                'required' => true,
+                'allow_add' => true,
+                'allow_delete' => true,
+            ]
+        );
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -18,6 +18,7 @@ monsieurbiz_searchplugin:
       instant_search_enabled_monsieurbiz_product: 'Product: Instant search enabled'
       limit_search_monsieurbiz_product: 'Product: Available limits for search'
       limit_instant_search_monsieurbiz_product: 'Product: Available limits for instant search'
+      limit_taxon_monsieurbiz_product: 'Product: Available limits for category overview'
   form:
     query: 'Search'
     query_placeholder: 'Search…'

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -18,6 +18,7 @@ monsieurbiz_searchplugin:
       instant_search_enabled_monsieurbiz_product: 'Produit: Activer la recherche instantanée'
       limit_search_monsieurbiz_product: 'Produit: Limites disponibles pour la recherche'
       limit_instant_search_monsieurbiz_product: 'Produit: Limites disponibles pour la recherche instantanée'
+      limit_taxon_monsieurbiz_product: 'Produit: Limites disponibles pour les catégories'
   form:
     query: 'Recherche'
     query_placeholder: 'Rechercher…'


### PR DESCRIPTION
Added the missing inputs for taxon limits.

The plugin creates an entry with the "taxon" key and "[9, 18, 27]" as value. But it cannot be edited, which is weird.

