### PR TITLE
Fix indexation: with sylius > 1.12, avoid documentable always not translable

### DIFF
--- a/src/Model/Documentable/Documentable.php
+++ b/src/Model/Documentable/Documentable.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusSearchPlugin\Model\Documentable;
 
-use Sylius\Component\Resource\Model\TranslatableInterface;
+use Sylius\Component\Resource\Model\TranslatableInterface as OldTranslatableInterface;
+use Sylius\Resource\Model\TranslatableInterface;
 
 class Documentable implements PrefixedDocumentableInterface
 {
@@ -68,7 +69,8 @@ class Documentable implements PrefixedDocumentableInterface
     {
         $interface = (array) class_implements($this->getSourceClass());
 
-        return \in_array(TranslatableInterface::class, $interface, true);
+        return \in_array(TranslatableInterface::class, $interface, true)
+            || \in_array(OldTranslatableInterface::class, $interface, true);
     }
 
     public function getTemplate(string $type): ?string


### PR DESCRIPTION
With multiple locale, without the fix we have only one ES index for all…

![image](https://github.com/user-attachments/assets/ac416f3f-1720-47a8-8d42-c79490773bc0)

**Before**

![image](https://github.com/user-attachments/assets/9d52efb4-757e-431e-9de3-a260aac1268c)
![image](https://github.com/user-attachments/assets/1ce12268-e302-4183-8e12-e7dc37d3c761)

**After**

![image](https://github.com/user-attachments/assets/e980f338-fd5e-43ab-902a-2f345c247225)
![image](https://github.com/user-attachments/assets/9e914533-8a88-40d3-bf68-72386a6968f7)
