### PR TITLE
add standar search to analyzer 

### DIFF
--- a/src/Resources/config/elasticsearch/monsieurbiz_product_mapping.yaml
+++ b/src/Resources/config/elasticsearch/monsieurbiz_product_mapping.yaml
@@ -14,6 +14,7 @@ mappings:
           type: keyword
     name:
       type: text
+      analyzer: search_standard
       fields:
         keyword:
           type: keyword


### PR DESCRIPTION
We add this line on mapping product ```analyzer: search_standard```  

before :
<img width="1727" height="844" alt="image" src="https://github.com/user-attachments/assets/8fae1537-f4f2-4f01-bd9b-4efa799c84d2" />
after :
<img width="1727" height="844" alt="image" src="https://github.com/user-attachments/assets/30245fe9-983a-4840-864e-1bf426968a86" />
